### PR TITLE
changed links to a yellow highlighter style

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -25,3 +25,13 @@ button:hover {
   background-color: #526d7a;
   color: white;
 }
+
+h6 a {
+  text-decoration: underline;
+  box-shadow: none !important;
+  border-bottom: none !important;
+}
+
+h6 a:hover {
+  background: transparent;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -11,14 +11,19 @@
     width: device-width;
 }
 
+a:hover {
+    background: #f7ebb6;
+    text-decoration: none;
+}
+
 a,
-a:hover,
 a:focus,
 a:visited,
 a:link
 {
-    text-decoration: underline;
-    color: #1b34bd;
+    color: #777;
+    box-shadow: inset 0 -4px 0 #f7ebb6;
+    border-bottom: 1px solid #f7ebb6;
 }
 body
 {


### PR DESCRIPTION
Inspired by [this](https://matt3o.com/) site. Changed links to look more modern. Links are now underlined with a highlighter looking line. When hovering, it makes the whole word look highlighted. In the example below, the one link that is completely highlighted is being hovered over with my mouse:

![image](https://user-images.githubusercontent.com/92005775/163841422-f23cfde6-1d07-4e16-a199-919809430a65.png)
