### PR TITLE
added table of contents to posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,9 @@ author = "Until It's Not Fun"
 title = "Until It's Not Fun"
 
 [markup]
+  [markup.tableOfContents]
+    startLevel=2
+    endLevel=2
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true

--- a/content/posts/2022-04-11/index.md
+++ b/content/posts/2022-04-11/index.md
@@ -2,7 +2,7 @@
 title: "Special Edition: Test Run"
 date: 2022-04-11T16:09:32-07:00
 draft: false
-toc: false
+toc: true
 description: "In our first ever post, we test our workflow. Jacob reviews Deep Water and Westley writes about his new keyboard."
 ---
 ## Popcorn and A Coke

--- a/content/posts/2022-04-15/index.md
+++ b/content/posts/2022-04-15/index.md
@@ -2,7 +2,7 @@
 title: "IRC and Pig"
 date: 2022-04-15
 draft: false
-toc: false
+toc: true
 description: "Jacob reviews the movie Pig with Nicolas Cage and Westley writes about his experience exploring IRC."
 ---
 ## The Tech Shelf

--- a/content/posts/2022-04-22/index.md
+++ b/content/posts/2022-04-22/index.md
@@ -2,7 +2,7 @@
 title: "Jammy Jellyfish"
 date: 2022-04-22
 draft: false
-toc: false
+toc: true
 description: "Jacob is gone on a trip this week so it is just Westley talking about the release of Ubuntu 22.04."
 ---
 ## Popcorn and A Coke

--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -23,6 +23,7 @@
 <section id="content-pane" class="">
   <div class="col-md-12 text-justify content">
     {{ if and ( ne .Params.toc false) (gt .WordCount 300 ) }}
+    <b>Index</b>
     {{ .TableOfContents }}
     {{ end }}
     {{ .Content }}


### PR DESCRIPTION
@STAJacob what do you think about this?

I added a simplified table of contents to each post. You can click each entry to jump to each others post. So, someone that wants to look back at your notes for Pig for example could find it really quickly: go to posts -> find "IRC and Pig" -> jump to "Popcorn and a Coke"

Here is what the table of contents looks like:
![image](https://user-images.githubusercontent.com/92005775/165357026-0f194ef6-92e9-417d-b48c-dc690807029b.png)
